### PR TITLE
feat: add synchronous api

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ Map of packages resolution mappings.
 }
 ```
 
+### resolve.packagesSync(names, [ opts ])
+Alias: `byNameSync`
+
+Synchronous version of `packages`.
+Find and resolve modules and its dependencies recursively looking by package name.
+
+### resolve.manifestSync(pkgManifest, [ opts ])
+
+Synchronous version of `manifest`.
+Resolve dependencies recursively reading the `package.json` metadata.
+
 ## License
 
 MIT - Tomas Aparicio

--- a/index.js
+++ b/index.js
@@ -313,7 +313,7 @@ function resolvePackageSync (lookups) {
 
 function resolveManifestSync (main, pkg, lookups) {
   const base = path.dirname(main)
-  let manifestPath
+  var manifestPath
   try {
     manifestPath = findMainfestSync(base)
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engineStrict": true,
   "scripts": {
     "lint": "standard *.js",
-    "test": "npm run lint && tape test.js"
+    "test": "npm run lint && tape test.js test.sync.js"
   },
   "engines": {
     "node": ">= 0.12"

--- a/test.sync.js
+++ b/test.sync.js
@@ -1,0 +1,82 @@
+const test = require('tape')
+const resolve = require('./')
+
+function resolveSimple (assert) {
+  const pkgs = ['foo']
+  const opts = { basedir: __dirname + '/fixtures/simple' }
+  try {
+    assert(null, resolve.packagesSync(pkgs, opts))
+  } catch (err) {
+    assert(err)
+  }
+}
+
+test('find sync', function (t) {
+  t.plan(10)
+
+  resolveSimple(function assert (err, deps) {
+    t.equal(err, null)
+    t.equal(deps.length, 1)
+
+    const foo = deps.shift()
+    t.equal(foo.name, 'foo')
+    t.equal(typeof foo.manifest, 'string')
+    t.equal(typeof foo.basedir, 'string')
+    t.equal(typeof foo.main, 'string')
+    t.equal(typeof foo.root, 'string')
+
+    t.equal(foo.meta.name, 'foo')
+    t.equal(typeof foo.meta.dependencies, 'object')
+    t.equal(foo.dependencies.length, 3)
+  })
+})
+
+test('manifest sync', function (t) {
+  t.plan(9)
+
+  const manifest = require(__dirname + '/fixtures/simple/package.json')
+  const opts = { basedir: __dirname + '/fixtures/simple' }
+
+  const deps = resolve.manifestSync(manifest, opts)
+  t.equal(deps.length, 1)
+
+  const foo = deps.shift()
+  t.equal(foo.name, 'foo')
+  t.equal(typeof foo.manifest, 'string')
+  t.equal(typeof foo.basedir, 'string')
+  t.equal(typeof foo.main, 'string')
+  t.equal(typeof foo.root, 'string')
+
+  t.equal(foo.meta.name, 'foo')
+  t.equal(typeof foo.meta.dependencies, 'object')
+  t.equal(foo.dependencies.length, 3)
+})
+
+test('optional dependencies sync', function (t) {
+  t.plan(13)
+
+  const manifest = require(__dirname + '/fixtures/optional/package.json')
+  const opts = {
+    lookups: ['dependencies', 'optionalDependencies'],
+    basedir: __dirname + '/fixtures/optional'
+  }
+
+  const deps = resolve.manifestSync(manifest, opts)
+  t.equal(deps.length, 3)
+
+  const foo = deps.shift()
+  t.equal(foo.name, 'foo')
+  t.equal(typeof foo.manifest, 'string')
+  t.equal(typeof foo.basedir, 'string')
+  t.equal(typeof foo.main, 'string')
+  t.equal(typeof foo.root, 'string')
+  t.equal(foo.meta.name, 'foo')
+
+  const optional = deps.shift()
+  t.equal(optional.name, 'optional')
+  t.equal(typeof optional.manifest, 'string')
+  t.equal(typeof optional.basedir, 'string')
+  t.equal(typeof optional.main, 'string')
+  t.equal(typeof optional.root, 'string')
+  t.equal(optional.meta.name, 'optional')
+})


### PR DESCRIPTION
There are cases where synchronous apis are the only way to go, therefore
one might choose the slower api over the async one.
For example when running in a constructor of a class.

Closes #4